### PR TITLE
Added compatibility with Python 3.10

### DIFF
--- a/pgradd/GroupAdd/Library.py
+++ b/pgradd/GroupAdd/Library.py
@@ -1,6 +1,11 @@
 import os
 from warnings import warn
-from collections.abc import Mapping
+from sys import version_info
+if version_info > (3, 5):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 from .. import yaml_io
 import numpy as np
 

--- a/pgradd/GroupAdd/Library.py
+++ b/pgradd/GroupAdd/Library.py
@@ -1,6 +1,6 @@
 import os
 from warnings import warn
-from collections import Mapping
+from collections.abc import Mapping
 from .. import yaml_io
 import numpy as np
 

--- a/pgradd/yaml_io/builtins.py
+++ b/pgradd/yaml_io/builtins.py
@@ -1,4 +1,4 @@
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from .. import Units
 

--- a/pgradd/yaml_io/builtins.py
+++ b/pgradd/yaml_io/builtins.py
@@ -1,4 +1,9 @@
-from collections.abc import Mapping, Sequence
+from sys import version_info
+if version_info > (3, 5):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 
 from .. import Units
 

--- a/pgradd/yaml_io/schema.py
+++ b/pgradd/yaml_io/schema.py
@@ -1,4 +1,4 @@
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from warnings import warn
 
 from .common import string, SchemaDefinitionError, InputDataError,\

--- a/pgradd/yaml_io/schema.py
+++ b/pgradd/yaml_io/schema.py
@@ -1,4 +1,9 @@
-from collections.abc import Mapping, Sequence
+from sys import version_info
+if version_info > (3, 5):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 from warnings import warn
 
 from .common import string, SchemaDefinitionError, InputDataError,\


### PR DESCRIPTION
`ABC` imports were removed from `collections`. I corrected the imports for the version to work under Python 3.10.